### PR TITLE
Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "chrisreedio/laravel-azure-graph": "^0",
         "chrisreedio/socialment": "^v3.9.1",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0",
         "socialiteproviders/microsoft-azure": "^5.1",
         "spatie/laravel-package-tools": "^1.15.0"
     },


### PR DESCRIPTION
Deleted `illuminate/contracts` as it is no longer needed. This cleanup helps maintain project efficiency and clarity and support Laravel 12.